### PR TITLE
feat: add CanSendEffect hook for per-connection effect filtering

### DIFF
--- a/src/Carbon.Components/Carbon.Modules/src/VanishModule/VanishModule.cs
+++ b/src/Carbon.Components/Carbon.Modules/src/VanishModule/VanishModule.cs
@@ -134,6 +134,14 @@ public partial class VanishModule : CarbonModule<VanishConfig, EmptyModuleData>
 		_lastLooter = player;
 	}
 
+	private object CanSendEffect(Effect effect, Connection connection)
+	{
+		if (effect == null || effect.source == 0) return null;
+		if (connection != null && connection.userid == effect.source) return null;
+		if (IsPlayerVanished(effect.source)) return false;
+		return null;
+	}
+
 	private static void SendEffectTo(string effect, BasePlayer player)
 	{
 		if (player == null)
@@ -452,6 +460,7 @@ public partial class VanishModule : CarbonModule<VanishConfig, EmptyModuleData>
 		[UsedImplicitly]
 		public static bool Prefix(BasePlayer player, Translate.Phrase reason)
 		{
+			if (Singleton == null || !Singleton.IsEnabled()) return true;
 			return !Singleton.IsPlayerVanished(player);
 		}
 	}
@@ -547,18 +556,6 @@ public partial class VanishModule : CarbonModule<VanishConfig, EmptyModuleData>
 			]);
 
 			return codes;
-		}
-	}
-
-	[AutoPatch, HarmonyPatch(typeof(EffectNetwork), "Send", typeof(Effect), typeof(EntityNetworkRange))]
-	public static class EffectNetworkPatch
-	{
-		[UsedImplicitly]
-		[HarmonyPrefix]
-		public static bool Prefix(Effect effect, EntityNetworkRange networkRange)
-		{
-			if (effect == null || effect.source == 0) return true;
-			return Singleton == null || !Singleton.IsEnabled() || !Singleton.IsPlayerVanished(effect.source);
 		}
 	}
 

--- a/src/Carbon.Hooks/Carbon.Hooks.Community/Carbon.Hooks.Community.csproj
+++ b/src/Carbon.Hooks/Carbon.Hooks.Community/Carbon.Hooks.Community.csproj
@@ -11,6 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
 		<ProjectReference Include="$(SolutionDir)\Carbon\Carbon.csproj" Private="false" />
+		<ProjectReference Include="$(SolutionDir)\Carbon.Components\Carbon.Modules\Carbon.Modules.csproj" Private="false" />
 	</ItemGroup>
 
 	<Target Name="CustomRelease" AfterTargets="Build" DependsOnTargets="PrepareRelease">

--- a/src/Carbon.Hooks/Carbon.Hooks.Community/src/Engine/CanSendEffect.cs
+++ b/src/Carbon.Hooks/Carbon.Hooks.Community/src/Engine/CanSendEffect.cs
@@ -1,0 +1,134 @@
+﻿using System.Collections.Generic;
+using API.Hooks;
+using Facepunch;
+using Network;
+
+namespace Carbon.Hooks;
+
+#pragma warning disable IDE0051
+
+public partial class Category_Engine
+{
+	public partial class Engine_Hooks
+	{
+		[HookAttribute.Patch("CanSendEffect", "CanSendEffect", typeof(EffectNetwork), "Send", [typeof(Effect), typeof(EntityNetworkRange)])]
+
+		[MetadataAttribute.Category("Engine")]
+		[MetadataAttribute.Info("Called before an effect is sent to a connection. Return false to suppress the effect for that connection.")]
+		[MetadataAttribute.Parameter("effect", typeof(Effect))]
+		[MetadataAttribute.Parameter("connection", typeof(Connection))]
+		[MetadataAttribute.Return(typeof(bool))]
+
+		public class CanSendEffect : Patch
+		{
+			public static bool Prefix(Effect effect, EntityNetworkRange networkRange)
+			{
+				if (Net.sv == null) return true;
+				if (effect == null) return true;
+
+				// Resolve pooledstringid early, matching vanilla EffectNetwork.Send
+				if (effect.pooledstringid == 0 && !string.IsNullOrEmpty(effect.pooledString))
+				{
+					effect.pooledstringid = StringPool.Get(effect.pooledString);
+				}
+				if (effect.pooledstringid == 0) return true;
+
+				// Determine which connections would receive this effect.
+				// NOTE: This mirrors vanilla EffectNetwork.Send subscriber resolution and must be
+				// updated if the vanilla method changes, otherwise hooks may fire for wrong connections.
+				List<Connection> subscribers = null;
+
+				if (effect.broadcast)
+				{
+					subscribers = BaseNetworkable.GlobalNetworkGroup.subscribers;
+				}
+				else if (effect.targets != null)
+				{
+					subscribers = effect.targets;
+				}
+				else if (effect.entity > 0)
+				{
+					var baseEntity = BaseNetworkable.serverEntities.Find(effect.entity) as BaseEntity;
+					if (baseEntity.IsValid())
+					{
+						subscribers = baseEntity.net?.group?.subscribers;
+					}
+					else
+					{
+						return true;
+					}
+				}
+				else
+				{
+					var group = Net.sv.visibility.GetGroup(effect.worldPos, networkRange);
+					subscribers = group?.subscribers;
+				}
+
+				if (subscribers == null || subscribers.Count == 0) return true;
+
+				// Skip per-connection hook calls if no handler is registered for this hook
+				if (Community.Runtime != null && Community.Runtime.ModuleProcessor != null)
+				{
+					var hasHandler = false;
+					foreach (var _ in HookCaller.GetAllFor(2666115907u))
+					{
+						hasHandler = true;
+						break;
+					}
+					if (!hasHandler) return true;
+				}
+
+				// Call hook for each subscriber, filtering out suppressed connections
+				var suppressed = false;
+				var recipients = Pool.Get<List<Connection>>();
+				var connections = Pool.Get<List<Connection>>();
+
+				try
+				{
+					recipients.AddRange(subscribers);
+
+					for (int i = 0; i < recipients.Count; i++)
+					{
+						var conn = recipients[i];
+
+						if (conn != null && conn.connected && conn.isAuthenticated)
+						{
+							var result = HookCaller.CallStaticHook(2666115907u, effect, conn);
+
+							if (result is bool boolResult && !boolResult)
+							{
+								suppressed = true;
+								continue;
+							}
+
+							connections.Add(conn);
+						}
+					}
+
+					if (!suppressed)
+					{
+						return true;
+					}
+
+					if (connections.Count == 0)
+					{
+						return false;
+					}
+
+					// Partial suppression - manually send to remaining connections
+					var write = Net.sv.StartWrite();
+					write.PacketID(Message.Type.Effect);
+					effect.WriteToStream(write);
+					write.Send(new SendInfo(connections));
+
+					return false;
+				}
+				finally
+				{
+					Pool.FreeUnmanaged(ref recipients);
+					Pool.FreeUnmanaged(ref connections);
+				}
+			}
+		}
+	}
+}

--- a/src/Carbon.Hooks/Carbon.Hooks.Community/src/Engine/CanSendEffect.cs
+++ b/src/Carbon.Hooks/Carbon.Hooks.Community/src/Engine/CanSendEffect.cs
@@ -40,13 +40,13 @@ public partial class Category_Engine
 
 				if (effect.broadcast)
 				{
-					subscribers = BaseNetworkable.GlobalNetworkGroup.subscribers;
+					subscribers = BaseNetworkable.GlobalNetworkGroup?.subscribers;
 				}
 				else if (effect.targets != null)
 				{
 					subscribers = effect.targets;
 				}
-				else if (effect.entity > 0)
+				else if (effect.entity.Value > 0)
 				{
 					var baseEntity = BaseNetworkable.serverEntities.Find(effect.entity) as BaseEntity;
 					if (baseEntity.IsValid())

--- a/src/Carbon.Hooks/Carbon.Hooks.Community/src/Player/OnCarbonUnvanished.cs
+++ b/src/Carbon.Hooks/Carbon.Hooks.Community/src/Player/OnCarbonUnvanished.cs
@@ -1,0 +1,21 @@
+﻿using API.Hooks;
+using Carbon.Modules;
+
+namespace Carbon.Hooks;
+
+#pragma warning disable IDE0051
+
+public partial class Category_Player
+{
+	public partial class Player_Hooks
+	{
+		[HookAttribute.Patch("OnCarbonUnvanished", "OnCarbonUnvanished", typeof(VanishModule), nameof(VanishModule.DoVanish))]
+		[HookAttribute.Options(HookFlags.MetadataOnly)]
+
+		[MetadataAttribute.Category("Player")]
+		[MetadataAttribute.Info("Called when a player becomes unvanished.")]
+		[MetadataAttribute.Parameter("player", typeof(BasePlayer))]
+
+		public class OnCarbonUnvanished : Patch;
+	}
+}

--- a/src/Carbon.Hooks/Carbon.Hooks.Community/src/Player/OnCarbonVanished.cs
+++ b/src/Carbon.Hooks/Carbon.Hooks.Community/src/Player/OnCarbonVanished.cs
@@ -1,0 +1,21 @@
+﻿using API.Hooks;
+using Carbon.Modules;
+
+namespace Carbon.Hooks;
+
+#pragma warning disable IDE0051
+
+public partial class Category_Player
+{
+	public partial class Player_Hooks
+	{
+		[HookAttribute.Patch("OnCarbonVanished", "OnCarbonVanished", typeof(VanishModule), nameof(VanishModule.DoVanish))]
+		[HookAttribute.Options(HookFlags.MetadataOnly)]
+
+		[MetadataAttribute.Category("Player")]
+		[MetadataAttribute.Info("Called when a player becomes vanished.")]
+		[MetadataAttribute.Parameter("player", typeof(BasePlayer))]
+
+		public class OnCarbonVanished : Patch;
+	}
+}


### PR DESCRIPTION
Summary

Adds a `CanSendEffect` hook that enables per connection effect filtering, replacing the previous all or nothing EffectNetworkPatch inside VanishModule. Also adds OnCarbonVanished and OnCarbonUnvanished hook definitions for the VanishModule.

- Better suppression behavior
  - Vanished players can see their own effects while they are still hidden from other players
- More extensible 
  - `CanSendEffect`, `OnCarbonVanished`, and `OnCarbonUnvanished` are hooks that plugins can use, instead of being locked inside the module

Includes an unrelated one-line bug fix for a potential NRE in the OwnershipPatch that doesnt have an issue tracking it
`			if (Singleton == null || !Singleton.IsEnabled()) return true;`