### PR TITLE
Improve command error handling with compatibility detection and early validation

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Components/Localisation.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Components/Localisation.cs
@@ -16,7 +16,8 @@ public struct Localisation
 		["unknown_chat_cmd_separator_2"] = " or ",
 		["no_perm"] = "You don't have any of the required permissions to run this command.",
 		["no_group"] = "You aren't in any of the required groups to run this command.",
-		["no_auth"] = $"You don't have the minimum auth level [{{0}}] required to execute this command [your level: {{1}}]."
+		["no_auth"] = $"You don't have the minimum auth level [{{0}}] required to execute this command [your level: {{1}}].",
+		["cmd_failed_compat"] = "That command is temporarily unavailable. Check the server console for details."
 	};
 
 	public static string Get(string key, string playerId)

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Config.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Config.cs
@@ -110,6 +110,7 @@ public class Config
 		public int LogVerbosity = 0;
 		public bool CommandSuggestions = true;
 		public bool ReducedLogging = true;
+		public bool ShowCommandCompatibilityErrors = false;
 	}
 
 	public class AnalyticsConfig

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
@@ -7,6 +7,7 @@ public static class ExceptionEx
 {
 	private static readonly Regex _missingMethodRegex = new(@"Method not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
 	private static readonly Regex _missingFieldRegex = new(@"Field not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
+	private static readonly Regex _typeLoadAssemblyRegex = new(@"from assembly\s+['""]([^'""]+)['""]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 	private static string GetSimpleAssemblyName(string fileName)
 	{
@@ -33,6 +34,72 @@ public static class ExceptionEx
 			assemblyName.StartsWith("Carbon.", StringComparison.OrdinalIgnoreCase);
 	}
 
+	private static bool IsCompatibilityTypeLoad(TypeLoadException exception)
+	{
+		var assemblyMatch = _typeLoadAssemblyRegex.Match(exception.Message);
+		if (assemblyMatch.Success && IsCompatibilityAssembly(GetSimpleAssemblyName(assemblyMatch.Groups[1].Value)))
+			return true;
+
+		if (string.IsNullOrEmpty(exception.TypeName))
+			return false;
+
+		var genericDepth = 0;
+		var commaIndex = -1;
+		for (var i = 0; i < exception.TypeName.Length; i++)
+		{
+			switch (exception.TypeName[i])
+			{
+				case '[':
+					genericDepth++;
+					break;
+				case ']':
+					genericDepth--;
+					break;
+				case ',' when genericDepth == 0:
+					commaIndex = i;
+					break;
+			}
+
+			if (commaIndex >= 0)
+				break;
+		}
+
+		return commaIndex >= 0 && IsCompatibilityAssembly(GetSimpleAssemblyName(exception.TypeName[(commaIndex + 1)..]));
+	}
+
+	private static bool TryGetCompatibilityException(Exception exception, out Exception result)
+	{
+		var ex = exception;
+		while (ex != null)
+		{
+			if (ex is MissingMemberException or BadImageFormatException ||
+				ex is TypeLoadException typeLoad && IsCompatibilityTypeLoad(typeLoad))
+			{
+				result = ex;
+				return true;
+			}
+
+			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
+			{
+				result = ex;
+				return true;
+			}
+
+			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
+			{
+				result = ex;
+				return true;
+			}
+
+			ex = ex.InnerException;
+		}
+
+		result = null;
+		return false;
+	}
+
 	public static string GetFullStackTrace(this Exception exception, bool mainMessage = true)
 	{
 		var fullStackTrace = mainMessage ? exception.ToString() : exception.StackTrace;
@@ -49,46 +116,12 @@ public static class ExceptionEx
 
 	public static bool IsCompatibilityError(this Exception exception)
 	{
-		var ex = exception;
-		while (ex != null)
-		{
-			if (ex is MissingMemberException or TypeLoadException or BadImageFormatException)
-				return true;
-
-			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
-					return true;
-
-			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
-					return true;
-
-			ex = ex.InnerException;
-		}
-
-		return false;
+		return TryGetCompatibilityException(exception, out _);
 	}
 
 	public static Exception GetCompatibilityException(this Exception exception)
 	{
-		var ex = exception;
-		while (ex != null)
-		{
-			if (ex is MissingMemberException or TypeLoadException or BadImageFormatException)
-				return ex;
-
-			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
-					return ex;
-
-			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
-					return ex;
-
-			ex = ex.InnerException;
-		}
-
-		return exception;
+		return TryGetCompatibilityException(exception, out var result) ? result : exception;
 	}
 
 	public static string GetCompatibilityMessage(this Exception exception)
@@ -100,56 +133,41 @@ public static class ExceptionEx
 
 	public static string ExtractMissingMember(this Exception exception)
 	{
-		var ex = exception;
-		while (ex != null)
+		if (!TryGetCompatibilityException(exception, out var ex))
+			return string.Empty;
+
+		if (ex is MissingFieldException missingField)
 		{
-			if (ex is MissingFieldException missingField)
-			{
-				var match = _missingFieldRegex.Match(missingField.Message);
-				if (match.Success)
-					return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
+			var match = _missingFieldRegex.Match(missingField.Message);
+			if (match.Success)
+				return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
 
-				return missingField.Message;
-			}
-
-			if (ex is MissingMethodException missingMethod)
-			{
-				var match = _missingMethodRegex.Match(missingMethod.Message);
-				if (match.Success)
-					return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
-
-				return missingMethod.Message;
-			}
-
-			if (ex is MissingMemberException missingMember)
-			{
-				return missingMember.Message;
-			}
-
-			if (ex is TypeLoadException typeLoad)
-			{
-				return string.IsNullOrEmpty(typeLoad.TypeName) ? ex.Message : typeLoad.TypeName;
-			}
-
-			if (ex is BadImageFormatException badImage)
-			{
-				return string.IsNullOrEmpty(badImage.FileName) ? ex.Message : badImage.FileName;
-			}
-
-			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
-			{
-				return GetSimpleAssemblyName(fileNotFound.FileName);
-			}
-
-			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
-				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
-			{
-				return GetSimpleAssemblyName(fileLoad.FileName);
-			}
-
-			ex = ex.InnerException;
+			return missingField.Message;
 		}
+
+		if (ex is MissingMethodException missingMethod)
+		{
+			var match = _missingMethodRegex.Match(missingMethod.Message);
+			if (match.Success)
+				return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
+
+			return missingMethod.Message;
+		}
+
+		if (ex is MissingMemberException missingMember)
+			return missingMember.Message;
+
+		if (ex is TypeLoadException typeLoad)
+			return string.IsNullOrEmpty(typeLoad.TypeName) ? ex.Message : typeLoad.TypeName;
+
+		if (ex is BadImageFormatException badImage)
+			return string.IsNullOrEmpty(badImage.FileName) ? ex.Message : badImage.FileName;
+
+		if (ex is FileNotFoundException fileNotFound)
+			return GetSimpleAssemblyName(fileNotFound.FileName);
+
+		if (ex is FileLoadException fileLoad)
+			return GetSimpleAssemblyName(fileLoad.FileName);
 
 		return string.Empty;
 	}

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
@@ -34,28 +34,52 @@ public static class ExceptionEx
 			assemblyName.StartsWith("Carbon.", StringComparison.OrdinalIgnoreCase);
 	}
 
-	private static bool IsCompatibilityMissingMember(MissingMemberException exception)
+	private static bool TryExtractMissingMember(MissingMemberException exception, out string member)
 	{
-		if (string.IsNullOrEmpty(exception.Message))
-			return false;
-
-		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(assembly => IsCompatibilityAssembly(assembly.GetName().Name)))
+		var regex = exception switch
 		{
-			Type[] types;
-			try
-			{
-				types = assembly.GetTypes();
-			}
-			catch (ReflectionTypeLoadException ex)
-			{
-				types = ex.Types;
-			}
-
-			if (types.Any(type => type?.FullName != null && exception.Message.IndexOf(type.FullName.Replace('+', '.'), StringComparison.Ordinal) >= 0))
-				return true;
+			MissingMethodException => _missingMethodRegex,
+			MissingFieldException => _missingFieldRegex,
+			_ => null
+		};
+		var match = regex?.Match(exception.Message);
+		if (match?.Success != true)
+		{
+			member = string.Empty;
+			return false;
 		}
 
-		return false;
+		member = (match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value).Trim();
+		return !string.IsNullOrEmpty(member);
+	}
+
+	private static bool IsCompatibilityMissingMember(MissingMemberException exception)
+	{
+		if (!TryExtractMissingMember(exception, out var member))
+			return false;
+
+		var parameterIndex = member.IndexOf('(');
+		if (parameterIndex >= 0)
+			member = member[..parameterIndex];
+
+		var constructorIndex = member.LastIndexOf("..", StringComparison.Ordinal);
+		var memberIndex = constructorIndex >= 0 ? constructorIndex : member.LastIndexOf('.');
+		if (memberIndex <= 0)
+			return false;
+
+		var declaringTypeName = member[..memberIndex];
+		var returnTypeIndex = declaringTypeName.IndexOf(' ');
+		if (returnTypeIndex >= 0)
+			declaringTypeName = declaringTypeName[(returnTypeIndex + 1)..];
+
+		var declaringType = AccessToolsEx.TypeByName(declaringTypeName);
+		if (declaringType != null)
+			return IsCompatibilityAssembly(declaringType.Assembly.GetName().Name);
+
+		return AppDomain.CurrentDomain.GetAssemblies()
+			.Where(assembly => IsCompatibilityAssembly(assembly.GetName().Name))
+			.SelectMany(AccessToolsEx.GetTypesFromAssembly)
+			.Any(type => type.FullName != null && type.FullName.Replace('+', '.').Equals(declaringTypeName, StringComparison.Ordinal));
 	}
 
 	private static bool IsCompatibilityTypeLoad(TypeLoadException exception)
@@ -167,26 +191,8 @@ public static class ExceptionEx
 		if (!TryGetCompatibilityException(exception, out var ex))
 			return string.Empty;
 
-		if (ex is MissingFieldException missingField)
-		{
-			var match = _missingFieldRegex.Match(missingField.Message);
-			if (match.Success)
-				return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
-
-			return missingField.Message;
-		}
-
-		if (ex is MissingMethodException missingMethod)
-		{
-			var match = _missingMethodRegex.Match(missingMethod.Message);
-			if (match.Success)
-				return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
-
-			return missingMethod.Message;
-		}
-
 		if (ex is MissingMemberException missingMember)
-			return missingMember.Message;
+			return TryExtractMissingMember(missingMember, out var member) ? member : missingMember.Message;
 
 		if (ex is TypeLoadException typeLoad)
 			return string.IsNullOrEmpty(typeLoad.TypeName) ? ex.Message : typeLoad.TypeName;

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Concurrent;
+using System.IO;
 using System.Text.RegularExpressions;
 
 namespace Carbon.Extensions;
@@ -8,6 +9,12 @@ public static class ExceptionEx
 	private static readonly Regex _missingMethodRegex = new(@"Method not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
 	private static readonly Regex _missingFieldRegex = new(@"Field not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
 	private static readonly Regex _typeLoadAssemblyRegex = new(@"from assembly\s+['""]([^'""]+)['""]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	private static readonly ConcurrentDictionary<string, bool> _compatibilityTypeCache = new();
+
+	static ExceptionEx()
+	{
+		AppDomain.CurrentDomain.AssemblyLoad += (_, _) => _compatibilityTypeCache.Clear();
+	}
 
 	private static string GetSimpleAssemblyName(string fileName)
 	{
@@ -72,14 +79,17 @@ public static class ExceptionEx
 		if (returnTypeIndex >= 0)
 			declaringTypeName = declaringTypeName[(returnTypeIndex + 1)..];
 
-		var declaringType = AccessToolsEx.TypeByName(declaringTypeName);
-		if (declaringType != null)
-			return IsCompatibilityAssembly(declaringType.Assembly.GetName().Name);
+		return _compatibilityTypeCache.GetOrAdd(declaringTypeName, static typeName =>
+		{
+			var declaringType = AccessToolsEx.TypeByName(typeName);
+			if (declaringType != null)
+				return IsCompatibilityAssembly(declaringType.Assembly.GetName().Name);
 
-		return AppDomain.CurrentDomain.GetAssemblies()
-			.Where(assembly => IsCompatibilityAssembly(assembly.GetName().Name))
-			.SelectMany(AccessToolsEx.GetTypesFromAssembly)
-			.Any(type => type.FullName != null && type.FullName.Replace('+', '.').Equals(declaringTypeName, StringComparison.Ordinal));
+			return AppDomain.CurrentDomain.GetAssemblies()
+				.Where(assembly => IsCompatibilityAssembly(assembly.GetName().Name))
+				.SelectMany(AccessToolsEx.GetTypesFromAssembly)
+				.Any(type => type.FullName != null && type.FullName.Replace('+', '.').Equals(typeName, StringComparison.Ordinal));
+		});
 	}
 
 	private static bool IsCompatibilityTypeLoad(TypeLoadException exception)
@@ -115,7 +125,7 @@ public static class ExceptionEx
 		return commaIndex >= 0 && IsCompatibilityAssembly(GetSimpleAssemblyName(exception.TypeName[(commaIndex + 1)..]));
 	}
 
-	private static bool TryGetCompatibilityException(Exception exception, out Exception result)
+	public static bool TryGetCompatibilityException(this Exception exception, out Exception result)
 	{
 		var ex = exception;
 		while (ex != null)
@@ -181,29 +191,39 @@ public static class ExceptionEx
 
 	public static string GetCompatibilityMessage(this Exception exception)
 	{
-		var member = exception.GetCompatibilityException().ExtractMissingMember();
+		return exception.GetCompatibilityMessage(exception.GetCompatibilityException());
+	}
+
+	public static string GetCompatibilityMessage(this Exception exception, Exception compatibilityException)
+	{
+		var member = exception.ExtractMissingMember(compatibilityException);
 		var suffix = string.IsNullOrEmpty(member) ? string.Empty : $" ('{member}')";
 		return $"This usually means the Rust/Carbon/plugin versions are out of sync{suffix}. Try updating Carbon, the module/plugin, or the Rust server.";
 	}
 
 	public static string ExtractMissingMember(this Exception exception)
 	{
-		if (!TryGetCompatibilityException(exception, out var ex))
+		if (!TryGetCompatibilityException(exception, out var compatibilityException))
 			return string.Empty;
 
-		if (ex is MissingMemberException missingMember)
+		return exception.ExtractMissingMember(compatibilityException);
+	}
+
+	public static string ExtractMissingMember(this Exception exception, Exception compatibilityException)
+	{
+		if (compatibilityException is MissingMemberException missingMember)
 			return TryExtractMissingMember(missingMember, out var member) ? member : missingMember.Message;
 
-		if (ex is TypeLoadException typeLoad)
-			return string.IsNullOrEmpty(typeLoad.TypeName) ? ex.Message : typeLoad.TypeName;
+		if (compatibilityException is TypeLoadException typeLoad)
+			return string.IsNullOrEmpty(typeLoad.TypeName) ? compatibilityException.Message : typeLoad.TypeName;
 
-		if (ex is BadImageFormatException badImage)
-			return string.IsNullOrEmpty(badImage.FileName) ? ex.Message : badImage.FileName;
+		if (compatibilityException is BadImageFormatException badImage)
+			return string.IsNullOrEmpty(badImage.FileName) ? compatibilityException.Message : badImage.FileName;
 
-		if (ex is FileNotFoundException fileNotFound)
+		if (compatibilityException is FileNotFoundException fileNotFound)
 			return GetSimpleAssemblyName(fileNotFound.FileName);
 
-		if (ex is FileLoadException fileLoad)
+		if (compatibilityException is FileLoadException fileLoad)
 			return GetSimpleAssemblyName(fileLoad.FileName);
 
 		return string.Empty;

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
@@ -34,6 +34,30 @@ public static class ExceptionEx
 			assemblyName.StartsWith("Carbon.", StringComparison.OrdinalIgnoreCase);
 	}
 
+	private static bool IsCompatibilityMissingMember(MissingMemberException exception)
+	{
+		if (string.IsNullOrEmpty(exception.Message))
+			return false;
+
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(assembly => IsCompatibilityAssembly(assembly.GetName().Name)))
+		{
+			Type[] types;
+			try
+			{
+				types = assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException ex)
+			{
+				types = ex.Types;
+			}
+
+			if (types.Any(type => type?.FullName != null && exception.Message.IndexOf(type.FullName.Replace('+', '.'), StringComparison.Ordinal) >= 0))
+				return true;
+		}
+
+		return false;
+	}
+
 	private static bool IsCompatibilityTypeLoad(TypeLoadException exception)
 	{
 		var assemblyMatch = _typeLoadAssemblyRegex.Match(exception.Message);
@@ -72,8 +96,15 @@ public static class ExceptionEx
 		var ex = exception;
 		while (ex != null)
 		{
-			if (ex is MissingMemberException or BadImageFormatException ||
+			if (ex is MissingMemberException missingMember && IsCompatibilityMissingMember(missingMember) ||
 				ex is TypeLoadException typeLoad && IsCompatibilityTypeLoad(typeLoad))
+			{
+				result = ex;
+				return true;
+			}
+
+			if (ex is BadImageFormatException badImage && !string.IsNullOrEmpty(badImage.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(badImage.FileName)))
 			{
 				result = ex;
 				return true;

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Extensions/ExceptionEx.cs
@@ -1,7 +1,38 @@
-﻿namespace Carbon.Extensions;
+﻿using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Carbon.Extensions;
 
 public static class ExceptionEx
 {
+	private static readonly Regex _missingMethodRegex = new(@"Method not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
+	private static readonly Regex _missingFieldRegex = new(@"Field not found:\s*(?:'([^']+)'|(.+))", RegexOptions.Compiled);
+
+	private static string GetSimpleAssemblyName(string fileName)
+	{
+		if (string.IsNullOrEmpty(fileName))
+			return string.Empty;
+
+		var name = Path.GetFileNameWithoutExtension(fileName);
+		var commaIndex = name.IndexOf(',');
+		if (commaIndex >= 0)
+			name = name[..commaIndex];
+
+		return name.Trim();
+	}
+
+	private static bool IsCompatibilityAssembly(string assemblyName)
+	{
+		if (string.IsNullOrEmpty(assemblyName))
+			return false;
+
+		return assemblyName.Equals("Assembly-CSharp", StringComparison.OrdinalIgnoreCase) ||
+			assemblyName.Equals("Rust", StringComparison.OrdinalIgnoreCase) ||
+			assemblyName.StartsWith("Rust.", StringComparison.OrdinalIgnoreCase) ||
+			assemblyName.Equals("Carbon", StringComparison.OrdinalIgnoreCase) ||
+			assemblyName.StartsWith("Carbon.", StringComparison.OrdinalIgnoreCase);
+	}
+
 	public static string GetFullStackTrace(this Exception exception, bool mainMessage = true)
 	{
 		var fullStackTrace = mainMessage ? exception.ToString() : exception.StackTrace;
@@ -14,5 +45,112 @@ public static class ExceptionEx
 		}
 
 		return fullStackTrace;
+	}
+
+	public static bool IsCompatibilityError(this Exception exception)
+	{
+		var ex = exception;
+		while (ex != null)
+		{
+			if (ex is MissingMemberException or TypeLoadException or BadImageFormatException)
+				return true;
+
+			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
+					return true;
+
+			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
+					return true;
+
+			ex = ex.InnerException;
+		}
+
+		return false;
+	}
+
+	public static Exception GetCompatibilityException(this Exception exception)
+	{
+		var ex = exception;
+		while (ex != null)
+		{
+			if (ex is MissingMemberException or TypeLoadException or BadImageFormatException)
+				return ex;
+
+			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
+					return ex;
+
+			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
+					return ex;
+
+			ex = ex.InnerException;
+		}
+
+		return exception;
+	}
+
+	public static string GetCompatibilityMessage(this Exception exception)
+	{
+		var member = exception.GetCompatibilityException().ExtractMissingMember();
+		var suffix = string.IsNullOrEmpty(member) ? string.Empty : $" ('{member}')";
+		return $"This usually means the Rust/Carbon/plugin versions are out of sync{suffix}. Try updating Carbon, the module/plugin, or the Rust server.";
+	}
+
+	public static string ExtractMissingMember(this Exception exception)
+	{
+		var ex = exception;
+		while (ex != null)
+		{
+			if (ex is MissingFieldException missingField)
+			{
+				var match = _missingFieldRegex.Match(missingField.Message);
+				if (match.Success)
+					return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
+
+				return missingField.Message;
+			}
+
+			if (ex is MissingMethodException missingMethod)
+			{
+				var match = _missingMethodRegex.Match(missingMethod.Message);
+				if (match.Success)
+					return match.Groups[1].Success ? match.Groups[1].Value.Trim() : match.Groups[2].Value.Trim();
+
+				return missingMethod.Message;
+			}
+
+			if (ex is MissingMemberException missingMember)
+			{
+				return missingMember.Message;
+			}
+
+			if (ex is TypeLoadException typeLoad)
+			{
+				return string.IsNullOrEmpty(typeLoad.TypeName) ? ex.Message : typeLoad.TypeName;
+			}
+
+			if (ex is BadImageFormatException badImage)
+			{
+				return string.IsNullOrEmpty(badImage.FileName) ? ex.Message : badImage.FileName;
+			}
+
+			if (ex is FileNotFoundException fileNotFound && !string.IsNullOrEmpty(fileNotFound.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileNotFound.FileName)))
+			{
+				return GetSimpleAssemblyName(fileNotFound.FileName);
+			}
+
+			if (ex is FileLoadException fileLoad && !string.IsNullOrEmpty(fileLoad.FileName) &&
+				IsCompatibilityAssembly(GetSimpleAssemblyName(fileLoad.FileName)))
+			{
+				return GetSimpleAssemblyName(fileLoad.FileName);
+			}
+
+			ex = ex.InnerException;
+		}
+
+		return string.Empty;
 	}
 }

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -286,11 +286,11 @@ public class Command : Library
 			{
 				Name = command,
 				Reference = plugin,
-				Callback = arg =>
+				Callback = args =>
 				{
-					try { callback?.Invoke(null, command, arg.Arguments.ToStringArray()); }
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+					try { callback?.Invoke(null, command, args.Arguments.ToStringArray()); }
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); if (!args.PrintOutput) args.Reply = ex.Message; }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); if (!args.PrintOutput) args.Reply = ex.Message; }
 				},
 				Help = help,
 				Token = reference,

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -289,8 +289,8 @@ public class Command : Library
 				Callback = arg =>
 				{
 					try { callback?.Invoke(null, command, arg.Arguments.ToStringArray()); }
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); throw; }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); throw; }
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 				},
 				Help = help,
 				Token = reference,
@@ -417,6 +417,7 @@ public class Command : Library
 						}
 					}
 				}
+				catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", player, isChat: false); }
 				catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 			}
 			catch (TargetParameterCountException) { }

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -26,7 +26,7 @@ public class Command : Library
 
 	private static void LogCommandGenericError(string commandType, string command, BaseHookable plugin, Exception ex, string label)
 	{
-		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]", ex);
+		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]", ex is TargetInvocationException invocation ? invocation.InnerException ?? ex : ex);
 	}
 
 	private Func<API.Commands.Command, API.Commands.Command.Args, bool> OnPlayerExecute(bool isChat)
@@ -417,6 +417,7 @@ public class Command : Library
 						}
 					}
 				}
+				catch (TargetParameterCountException ex) { Logger.Error($"Failed executing console command '{command}' in '{plugin.ToPrettyString()}' [parameter count mismatch]", ex); }
 				catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", player, isChat: false); }
 				catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 			}

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -495,8 +495,8 @@ public class Command : Library
 						callback?.Invoke(arg);
 						args.Reply = arg.Reply;
 					}
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false, notifyPlayer: false); }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false, notifyPlayer: false); if (!args.PrintOutput) args.Reply = ex.Message; }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); if (!args.PrintOutput) args.Reply = ex.Message; }
 				},
 				Help = help,
 				Token = reference,

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -3,6 +3,7 @@ using Facepunch;
 using static ConsoleSystem;
 using Logger = Carbon.Logger;
 using Pool = Facepunch.Pool;
+using Carbon.Extensions;
 
 namespace Oxide.Game.Rust.Libraries;
 
@@ -11,6 +12,21 @@ public class Command : Library
 	public static bool FromRcon
 	{
 		get; set;
+	}
+
+	private static void LogCommandCompatibilityError(string commandType, string command, BaseHookable plugin, Exception ex, string label, BasePlayer player, bool isChat, bool notifyPlayer = true)
+	{
+		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]: {ex.GetCompatibilityMessage()}", ex.GetCompatibilityException());
+		if (notifyPlayer && Community.Runtime.Config.Logging.ShowCommandCompatibilityErrors && player != null)
+		{
+			if (isChat) player.ChatMessage(Localisation.Get("cmd_failed_compat", player.UserIDString));
+			else player.ConsoleMessage(Localisation.Get("cmd_failed_compat", player.UserIDString));
+		}
+	}
+
+	private static void LogCommandGenericError(string commandType, string command, BaseHookable plugin, Exception ex, string label)
+	{
+		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]", ex);
 	}
 
 	private Func<API.Commands.Command, API.Commands.Command.Args, bool> OnPlayerExecute(bool isChat)
@@ -102,7 +118,8 @@ public class Command : Library
 				{
 					case PlayerArgs playerArgs:
 						try { callback?.Invoke(playerArgs.Player as BasePlayer, command, arg.Arguments.ToStringArray()); }
-						catch (Exception ex) { Logger.Error($"Failed executing chat command '{command}' in '{plugin.ToPrettyString()}' [callback]", ex.InnerException ?? ex); }
+						catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("chat", command, plugin, ex, "callback", playerArgs.Player as BasePlayer, isChat: true); }
+						catch (Exception ex) { LogCommandGenericError("chat", command, plugin, ex, "callback"); }
 						break;
 				}
 			},
@@ -167,7 +184,7 @@ public class Command : Library
 							client.FromRcon = FromRcon;
 							arg.Option = client;
 							arg.FullString = fullString;
-							arg.Args = [.. args.Select(x => (StringView)x)];
+							arg.Args = [.. (args ?? []).Select(x => (StringView)x)];
 
 							arguments.Add(arg);
 						}
@@ -208,7 +225,8 @@ public class Command : Library
 
 				methodInfo?.Invoke(plugin, result);
 			}
-			catch (Exception ex) { Logger.Error($"Failed executing chat command '{command}' in '{plugin.ToPrettyString()}' [callback]", ex.InnerException ?? ex); }
+			catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("chat", command, plugin, ex, "callback", player, isChat: true); }
+			catch (Exception ex) { LogCommandGenericError("chat", command, plugin, ex, "callback"); }
 
 			if (arguments != null)
 			{
@@ -235,7 +253,9 @@ public class Command : Library
 					switch (arg)
 					{
 						case PlayerArgs playerArgs:
-							callback?.Invoke(playerArgs.Player as BasePlayer, command, arg.Arguments.ToStringArray());
+							try { callback?.Invoke(playerArgs.Player as BasePlayer, command, arg.Arguments.ToStringArray()); }
+							catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", playerArgs.Player as BasePlayer, isChat: false); }
+							catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 							break;
 					}
 				},
@@ -268,7 +288,9 @@ public class Command : Library
 				Reference = plugin,
 				Callback = arg =>
 				{
-					callback?.Invoke(null, command, arg.Arguments.ToStringArray());
+					try { callback?.Invoke(null, command, arg.Arguments.ToStringArray()); }
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 				},
 				Help = help,
 				Token = reference,
@@ -307,7 +329,7 @@ public class Command : Library
 				if (player != null) option = option.FromConnection(player.net.connection);
 				arg.Option = option;
 				arg.FullString = fullString;
-				arg.Args = args.ToStringViewArray();
+				arg.Args = (args ?? []).ToStringViewArray();
 				arg.cmd = Community.Runtime.CommandManager.Find(command)?.RustCommand;
 
 				try
@@ -395,10 +417,12 @@ public class Command : Library
 						}
 					}
 				}
-				catch (Exception ex) { Logger.Error($"Failed executing console command '{command}' in '{plugin.ToPrettyString()}' [callback]", ex.InnerException ?? ex); }
+				catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", player, isChat: false); }
+				catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 			}
-			catch (TargetParameterCountException) { }
-			catch (Exception ex) { Logger.Error ( $"Failed executing console command '{command}' in '{plugin.ToPrettyString ()}' [internal]", ex.InnerException ?? ex ); }
+			catch (TargetParameterCountException ex) { Logger.Error($"Failed executing console command '{command}' in '{plugin.ToPrettyString()}' [parameter count mismatch]", ex); }
+			catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "internal", player, isChat: false); }
+			catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "internal"); }
 
 			Pool.FreeUnmanaged(ref arguments);
 
@@ -422,9 +446,14 @@ public class Command : Library
 					{
 						return;
 					}
-					callback?.Invoke(arg);
-					args.Reply = arg.Reply;
-					args.PrintOutput = arg.Option.PrintOutput;
+					try
+					{
+						callback?.Invoke(arg);
+						args.Reply = arg.Reply;
+						args.PrintOutput = arg.Option.PrintOutput;
+					}
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false); }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 				},
 				Help = help,
 				Token = reference,
@@ -461,8 +490,13 @@ public class Command : Library
 					}
 
 					args.PrintOutput = arg.Option.PrintOutput;
-					callback?.Invoke(arg);
-					args.Reply = arg.Reply;
+					try
+					{
+						callback?.Invoke(arg);
+						args.Reply = arg.Reply;
+					}
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false, notifyPlayer: false); }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 				},
 				Help = help,
 				Token = reference,

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -14,9 +14,9 @@ public class Command : Library
 		get; set;
 	}
 
-	private static void LogCommandCompatibilityError(string commandType, string command, BaseHookable plugin, Exception ex, string label, BasePlayer player, bool isChat, bool notifyPlayer = true)
+	private static void LogCommandCompatibilityError(string commandType, string command, BaseHookable plugin, Exception ex, Exception compatEx, string label, BasePlayer player, bool isChat, bool notifyPlayer = true)
 	{
-		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]: {ex.GetCompatibilityMessage()}", ex.GetCompatibilityException());
+		Logger.Error($"Failed executing {commandType} command '{command}' in '{plugin.ToPrettyString()}' [{label}]: {ex.GetCompatibilityMessage(compatEx)}", compatEx);
 		if (notifyPlayer && Community.Runtime.Config.Logging.ShowCommandCompatibilityErrors && player != null)
 		{
 			if (isChat) player.ChatMessage(Localisation.Get("cmd_failed_compat", player.UserIDString));
@@ -118,8 +118,11 @@ public class Command : Library
 				{
 					case PlayerArgs playerArgs:
 						try { callback?.Invoke(playerArgs.Player as BasePlayer, command, arg.Arguments.ToStringArray()); }
-						catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("chat", command, plugin, ex, "callback", playerArgs.Player as BasePlayer, isChat: true); }
-						catch (Exception ex) { LogCommandGenericError("chat", command, plugin, ex, "callback"); }
+						catch (Exception ex)
+						{
+							if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("chat", command, plugin, ex, compatEx, "callback", playerArgs.Player as BasePlayer, isChat: true);
+							else LogCommandGenericError("chat", command, plugin, ex, "callback");
+						}
 						break;
 				}
 			},
@@ -184,7 +187,7 @@ public class Command : Library
 							client.FromRcon = FromRcon;
 							arg.Option = client;
 							arg.FullString = fullString;
-							arg.Args = [.. (args ?? []).Select(x => (StringView)x)];
+							arg.Args = [.. args.Select(x => (StringView)x)];
 
 							arguments.Add(arg);
 						}
@@ -225,8 +228,11 @@ public class Command : Library
 
 				methodInfo?.Invoke(plugin, result);
 			}
-			catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("chat", command, plugin, ex, "callback", player, isChat: true); }
-			catch (Exception ex) { LogCommandGenericError("chat", command, plugin, ex, "callback"); }
+			catch (Exception ex)
+			{
+				if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("chat", command, plugin, ex, compatEx, "callback", player, isChat: true);
+				else LogCommandGenericError("chat", command, plugin, ex, "callback");
+			}
 
 			if (arguments != null)
 			{
@@ -254,8 +260,11 @@ public class Command : Library
 					{
 						case PlayerArgs playerArgs:
 							try { callback?.Invoke(playerArgs.Player as BasePlayer, command, arg.Arguments.ToStringArray()); }
-							catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", playerArgs.Player as BasePlayer, isChat: false); }
-							catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+							catch (Exception ex)
+							{
+								if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "callback", playerArgs.Player as BasePlayer, isChat: false);
+								else LogCommandGenericError("console", command, plugin, ex, "callback");
+							}
 							break;
 					}
 				},
@@ -289,8 +298,19 @@ public class Command : Library
 				Callback = args =>
 				{
 					try { callback?.Invoke(null, command, args.Arguments.ToStringArray()); }
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); if (!args.PrintOutput) args.Reply = ex.Message; }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); if (!args.PrintOutput) args.Reply = ex.Message; }
+					catch (Exception ex)
+					{
+						if (ex.TryGetCompatibilityException(out var compatEx))
+						{
+							LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "callback", null, isChat: false, notifyPlayer: false);
+							if (!args.PrintOutput) args.Reply = $"{ex.GetCompatibilityMessage(compatEx)}\n{compatEx}";
+						}
+						else
+						{
+							LogCommandGenericError("console", command, plugin, ex, "callback");
+							if (!args.PrintOutput) args.Reply = ex.ToString();
+						}
+					}
 				},
 				Help = help,
 				Token = reference,
@@ -329,7 +349,7 @@ public class Command : Library
 				if (player != null) option = option.FromConnection(player.net.connection);
 				arg.Option = option;
 				arg.FullString = fullString;
-				arg.Args = (args ?? []).ToStringViewArray();
+				arg.Args = args.ToStringViewArray();
 				arg.cmd = Community.Runtime.CommandManager.Find(command)?.RustCommand;
 
 				try
@@ -417,12 +437,18 @@ public class Command : Library
 						}
 					}
 				}
-				catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", player, isChat: false); }
-				catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+				catch (Exception ex)
+				{
+					if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "callback", player, isChat: false);
+					else LogCommandGenericError("console", command, plugin, ex, "callback");
+				}
 			}
 			catch (TargetParameterCountException) { }
-			catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "internal", player, isChat: false); }
-			catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "internal"); }
+			catch (Exception ex)
+			{
+				if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "internal", player, isChat: false);
+				else LogCommandGenericError("console", command, plugin, ex, "internal");
+			}
 
 			Pool.FreeUnmanaged(ref arguments);
 
@@ -452,8 +478,11 @@ public class Command : Library
 						args.Reply = arg.Reply;
 						args.PrintOutput = arg.Option.PrintOutput;
 					}
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false); }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+					catch (Exception ex)
+					{
+						if (ex.TryGetCompatibilityException(out var compatEx)) LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "callback", arg.Player(), isChat: false);
+						else LogCommandGenericError("console", command, plugin, ex, "callback");
+					}
 				},
 				Help = help,
 				Token = reference,
@@ -495,8 +524,19 @@ public class Command : Library
 						callback?.Invoke(arg);
 						args.Reply = arg.Reply;
 					}
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", arg.Player(), isChat: false, notifyPlayer: false); if (!args.PrintOutput) args.Reply = ex.Message; }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); if (!args.PrintOutput) args.Reply = ex.Message; }
+					catch (Exception ex)
+					{
+						if (ex.TryGetCompatibilityException(out var compatEx))
+						{
+							LogCommandCompatibilityError("console", command, plugin, ex, compatEx, "callback", arg.Player(), isChat: false, notifyPlayer: false);
+							if (!args.PrintOutput) args.Reply = $"{ex.GetCompatibilityMessage(compatEx)}\n{compatEx}";
+						}
+						else
+						{
+							LogCommandGenericError("console", command, plugin, ex, "callback");
+							if (!args.PrintOutput) args.Reply = ex.ToString();
+						}
+					}
 				},
 				Help = help,
 				Token = reference,

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Command.cs
@@ -289,8 +289,8 @@ public class Command : Library
 				Callback = arg =>
 				{
 					try { callback?.Invoke(null, command, arg.Arguments.ToStringArray()); }
-					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); }
-					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
+					catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", null, isChat: false, notifyPlayer: false); throw; }
+					catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); throw; }
 				},
 				Help = help,
 				Token = reference,
@@ -417,11 +417,9 @@ public class Command : Library
 						}
 					}
 				}
-				catch (TargetParameterCountException ex) { Logger.Error($"Failed executing console command '{command}' in '{plugin.ToPrettyString()}' [parameter count mismatch]", ex); }
-				catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "callback", player, isChat: false); }
 				catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "callback"); }
 			}
-			catch (TargetParameterCountException ex) { Logger.Error($"Failed executing console command '{command}' in '{plugin.ToPrettyString()}' [parameter count mismatch]", ex); }
+			catch (TargetParameterCountException) { }
 			catch (Exception ex) when (ex.IsCompatibilityError()) { LogCommandCompatibilityError("console", command, plugin, ex, "internal", player, isChat: false); }
 			catch (Exception ex) { LogCommandGenericError("console", command, plugin, ex, "internal"); }
 

--- a/src/Carbon/src/Hooks/HookEx.cs
+++ b/src/Carbon/src/Hooks/HookEx.cs
@@ -94,6 +94,11 @@ public class HookEx : IDisposable, IHook
 			_runtime.Postfix = AccessTools.Method(type, "Postfix") ?? null;
 			_runtime.Transpiler = AccessTools.Method(type, "Transpiler") ?? null;
 
+			if (TargetType == null)
+			{
+				throw new Exception($"Hook '{HookFullName}' target class '{(string.IsNullOrEmpty(metadata.Target) ? "<none specified>" : metadata.Target)}' was not found in the current game assembly. This usually means the Rust/Carbon versions are out of sync.");
+			}
+
 			// Type generics need to handled differently from a standard type.
 			// Harmony/Mono.Cecil will not allow the patching of the generic type
 			// which means we need to find each type matching the constrain and

--- a/src/Carbon/src/Hooks/HookEx.cs
+++ b/src/Carbon/src/Hooks/HookEx.cs
@@ -96,7 +96,10 @@ public class HookEx : IDisposable, IHook
 
 			if (TargetType == null)
 			{
-				throw new Exception($"Hook '{HookFullName}' target class '{(string.IsNullOrEmpty(metadata.Target) ? "<none specified>" : metadata.Target)}' was not found in the current game assembly. This usually means the Rust/Carbon versions are out of sync.");
+				if (string.IsNullOrEmpty(metadata.Target))
+					throw new Exception($"Hook '{HookFullName}' does not specify a target class.");
+
+				throw new Exception($"Hook '{HookFullName}' target class '{metadata.Target}' was not found in the current game assembly. This usually means the Rust/Carbon versions are out of sync.");
 			}
 
 			// Type generics need to handled differently from a standard type.


### PR DESCRIPTION
## Summary
This PR detects version mismatch exceptions in plugin commands and hooks, producing clearer console output and optionally notifying players.

Console command callback exceptions are now handled within the registered command callback rather than propagating to CommandManager.Execute. As a result, Execute completes its normal path and returns true even when the underlying plugin callback fails. For RCON commands with output disabled, the callback places the error in args.Reply, allowing Execute to forward it through the normal RCON reply path instead of its outer exception handler. Generic failures retain the full exception and stack trace, while compatibility failures include both the friendly version-mismatch diagnosis and the resolved compatibility exception details.

## Before (generic error for all command failures):

>[ERRO] Failed executing chat command 'mycommand' in 'MyPlugin v1.0.0' [callback] (Exception has been thrown by the target of an invocation.)
  System.Reflection.TargetInvocationException: ...

- After (compatibility error detected):

>[ERRO] Failed executing chat command 'mycommand' in 'MyPlugin v1.0.0' [callback]: This usually means the Rust/Carbon/plugin versions are out of sync ('BasePlayer.SomeNewMethod()'). Try updating Carbon, the module/plugin, or the Rust server.
System.MissingMethodException: Method not found: 'BasePlayer.SomeNewMethod()'

## After (generic error, unchanged behavior):



>[ERRO] Failed executing chat command 'mycommand' in 'MyPlugin v1.0.0' [callback] (System.Exception: ...)

If ShowCommandCompatibilityErrors is enabled in config, the player also sees:

> That command is temporarily unavailable. Check the server console for details.

Hook target class not found now fails early with:

> [ERRO] Error while parsing 'OnPlayerChat' (Hook 'OnPlayerChat' target class 'Chat' was not found in the current game assembly. This usually means the Rust/Carbon versions are out of sync.)
