### PR TITLE
bugfix: preserve custom User-Agent header in WebRequest and add tests

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
@@ -475,7 +475,12 @@ public class WebRequests : Library
 			{
 				var request = base.GetWebRequest(address) as HttpWebRequest;
 
-				request.UserAgent = Community.Runtime.Analytics.UserAgent;
+				// Prefer a plugin-supplied User-Agent from Headers (set in Start before this runs).
+				// Unconditionally overwriting here previously broke Oxide-compatible header behavior.
+				var headerUserAgent = Headers[HttpRequestHeader.UserAgent];
+				request.UserAgent = string.IsNullOrEmpty(headerUserAgent)
+					? Community.Runtime.Analytics.UserAgent
+					: headerUserAgent;
 				request.AutomaticDecompression = AutomaticDecompression;
 
 				if (Community.IsConfigReady && !string.IsNullOrEmpty(Community.Runtime.Config.WebRequestIp))

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
@@ -17,6 +17,8 @@ public enum RequestMethod
 
 public class WebRequests : Library
 {
+	public static float Timeout = 30f;
+
 	public WebRequests()
 	{
 		ServicePointManager.Expect100Continue = false;
@@ -183,6 +185,9 @@ public class WebRequests : Library
 			_client.Proxy = null;
 			_client.Encoding = Encoding.UTF8;
 			_client.AutomaticDecompression = DecompressionMethod;
+
+			var milliseconds = (Timeout <= 0f ? WebRequests.Timeout : Timeout) * 1000f;
+			_client.Timeout = milliseconds >= int.MaxValue ? int.MaxValue : (int)milliseconds;
 
 			if (RequestHeaders != null && RequestHeaders.Count > 0)
 			{
@@ -412,6 +417,7 @@ public class WebRequests : Library
 		public class Client : WebClient
 		{
 			public int StatusCode { get; private set; }
+			public int Timeout { get; set; }
 			public DecompressionMethods AutomaticDecompression { get; set; } = DecompressionMethods.GZip;
 
 			public Client()
@@ -475,17 +481,23 @@ public class WebRequests : Library
 			{
 				var request = base.GetWebRequest(address) as HttpWebRequest;
 
-				// Prefer a plugin-supplied User-Agent from Headers (set in Start before this runs).
-				// Unconditionally overwriting here previously broke Oxide-compatible header behavior.
-				var headerUserAgent = Headers[HttpRequestHeader.UserAgent];
-				request.UserAgent = string.IsNullOrEmpty(headerUserAgent)
-					? Community.Runtime.Analytics.UserAgent
-					: headerUserAgent;
+				if (string.IsNullOrEmpty(request.UserAgent))
+				{
+					request.UserAgent = Community.Runtime.Analytics.UserAgent;
+				}
+
 				request.AutomaticDecompression = AutomaticDecompression;
 
-				if (Community.IsConfigReady && !string.IsNullOrEmpty(Community.Runtime.Config.WebRequestIp))
+				if (Timeout > 0)
 				{
-					request.ServicePoint.BindIPEndPointDelegate = (_, _, _) => new IPEndPoint(IPAddress.Parse(Community.Runtime.Config.WebRequestIp), 0);
+					request.Timeout = Timeout;
+				}
+
+				if (!address.IsLoopback && Community.IsConfigReady &&
+					IPAddress.TryParse(Community.Runtime.Config.WebRequestIp, out var bindAddress))
+				{
+					var bindEndPoint = new IPEndPoint(bindAddress, 0);
+					request.ServicePoint.BindIPEndPointDelegate = (_, _, _) => bindEndPoint;
 				}
 
 				return request;

--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/WebRequest.cs
@@ -440,6 +440,11 @@ public class WebRequests : Library
 				}
 				catch (WebException exp)
 				{
+					if (exp.Response == null)
+					{
+						throw;
+					}
+
 					response = exp.Response;
 
 					if (response is HttpWebResponse httpResponse)
@@ -466,6 +471,11 @@ public class WebRequests : Library
 				}
 				catch (WebException exp)
 				{
+					if (exp.Response == null)
+					{
+						throw;
+					}
+
 					response = exp.Response;
 
 					if (response is HttpWebResponse httpResponse)

--- a/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
+++ b/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
@@ -249,6 +249,29 @@ public partial class Tests
 		}
 
 		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task pooled_client_keeps_user_agent_across_requests(Integrations.Test.Assert test)
+		{
+			using var first = new LoopbackServer();
+			using var second = new LoopbackServer();
+			using var client = new WebRequests.WebRequest.Client();
+
+			client.Headers["User-Agent"] = Community.Runtime.Analytics.UserAgent;
+
+			await client.DownloadStringTaskAsync(new Uri(first.Url));
+			await client.DownloadStringTaskAsync(new Uri(second.Url));
+
+			var firstUserAgent = await first.GetHeader("User-Agent");
+			var secondUserAgent = await second.GetHeader("User-Agent");
+
+			test.IsTrue(firstUserAgent == Community.Runtime.Analytics.UserAgent,
+				$"pooled client sent the user agent on its first request (got '{firstUserAgent}')");
+			test.IsTrue(secondUserAgent == Community.Runtime.Analytics.UserAgent,
+				$"pooled client sent the user agent on its second request (got '{secondUserAgent}')");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
 		public async Task timeout_aborts_a_stalled_request(Integrations.Test.Assert test)
 		{
 			using var server = new LoopbackServer(respond: false);
@@ -284,9 +307,10 @@ public partial class Tests
 			{
 				var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test);
 
-				test.IsNull(result.Request.ResponseError, "loopback request has no response error");
+				test.IsTrue(result.CallbackCount == 1, "loopback callback invoked once");
 				test.IsTrue(result.CallbackCode == 204,
 					$"loopback request completed while web request ip is set ({result.CallbackCode})");
+				test.IsNull(result.Request.ResponseError, "loopback request has no response error");
 			}
 			finally
 			{

--- a/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
+++ b/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
@@ -1,6 +1,7 @@
 #if !TESTS_NO_WEBREQUEST
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -18,7 +19,8 @@ public partial class Tests
 	{
 		private const string HttpsGenerate204Url = "https://www.gstatic.com/generate_204";
 		private const string HttpGenerate204Url = "http://www.gstatic.com/generate_204";
-		private const string CustomPluginUserAgent = "Custom String";
+		private const string CustomUserAgent = "CarbonTests/1.0 (+plugin supplied)";
+		private const string UnreachableBindIp = "203.0.113.1";
 
 		[Integrations.Test.Assert]
 		public void validate_library(Integrations.Test.Assert test)
@@ -197,6 +199,99 @@ public partial class Tests
 				"invalid host request has response error");
 			test.IsTrue(result.CallbackCode == result.Request.ResponseCode,
 				$"invalid host callback/request response code match ({result.CallbackCode}/{result.Request.ResponseCode})");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task default_user_agent_is_carbons(Integrations.Test.Assert test)
+		{
+			using var probe = new LoopbackProbe();
+
+			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test);
+			var userAgent = await probe.GetHeader("User-Agent");
+
+			test.IsTrue(result.CallbackCode == 204, $"default user agent request completed ({result.CallbackCode})");
+			test.IsTrue(userAgent == Community.Runtime.Analytics.UserAgent,
+				$"default user agent is Carbon's (got '{userAgent}')");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task custom_user_agent_is_preserved(Integrations.Test.Assert test)
+		{
+			using var probe = new LoopbackProbe();
+
+			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test,
+				headers: new Dictionary<string, string> { ["User-Agent"] = CustomUserAgent });
+			var userAgent = await probe.GetHeader("User-Agent");
+
+			test.IsTrue(result.CallbackCode == 204, $"custom user agent request completed ({result.CallbackCode})");
+			test.IsTrue(userAgent == CustomUserAgent, $"custom user agent reached the wire (got '{userAgent}')");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task custom_user_agent_is_case_insensitive(Integrations.Test.Assert test)
+		{
+			using var probe = new LoopbackProbe();
+
+			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test,
+				headers: new Dictionary<string, string> { ["user-agent"] = CustomUserAgent });
+			var userAgent = await probe.GetHeader("User-Agent");
+
+			test.IsTrue(result.CallbackCode == 204, $"lowercase user agent request completed ({result.CallbackCode})");
+			test.IsTrue(userAgent == CustomUserAgent, $"lowercase user agent reached the wire (got '{userAgent}')");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task timeout_aborts_a_stalled_request(Integrations.Test.Assert test)
+		{
+			using var probe = new LoopbackProbe(respond: false);
+
+			var started = DateTime.UtcNow;
+			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test, 12_000, timeout: 2f);
+			var elapsed = (DateTime.UtcNow - started).TotalMilliseconds;
+
+			test.IsTrue(result.CallbackCount == 1, "stalled request callback invoked once");
+			test.IsTrue(result.Request.ResponseError != null, "stalled request surfaced a response error");
+			test.IsTrue(elapsed >= 1_000, $"stalled request waited for the timeout ({elapsed:0}ms)");
+			test.IsTrue(elapsed < 10_000, $"stalled request gave up on the timeout ({elapsed:0}ms)");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task loopback_request_ignores_webrequest_ip(Integrations.Test.Assert test)
+		{
+			if (!Community.IsConfigReady)
+			{
+				test.Warn("carbon config is not ready, skipping web request ip check");
+				test.Complete();
+				return;
+			}
+
+			using var probe = new LoopbackProbe();
+
+			var previousIp = Community.Runtime.Config.WebRequestIp;
+			Community.Runtime.Config.WebRequestIp = UnreachableBindIp;
+
+			try
+			{
+				var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test);
+
+				test.IsNull(result.Request.ResponseError, "loopback request has no response error");
+				test.IsTrue(result.CallbackCode == 204,
+					$"loopback request completed while web request ip is set ({result.CallbackCode})");
+			}
+			finally
+			{
+				Community.Runtime.Config.WebRequestIp = previousIp;
+			}
 
 			test.Complete();
 		}
@@ -430,110 +525,6 @@ public partial class Tests
 			}
 		}
 
-		[Integrations.Test.Assert(Timeout = 20_000)]
-		public async Task custom_user_agent_header_is_preserved(Integrations.Test.Assert test)
-		{
-			var capture = await CaptureInboundUserAgent(test, new Dictionary<string, string>
-			{
-				["User-Agent"] = CustomPluginUserAgent,
-			});
-
-			test.IsTrue(capture.CallbackCount == 1, "custom user-agent callback invoked once");
-			test.IsTrue(capture.CallbackCode == 204, "custom user-agent callback status code is 204");
-			test.IsTrue(capture.ReceivedUserAgent == CustomPluginUserAgent,
-				$"custom user-agent was sent (got '{capture.ReceivedUserAgent}')");
-			test.IsTrue(!string.Equals(capture.ReceivedUserAgent, Community.Runtime.Analytics.UserAgent, StringComparison.Ordinal),
-				"custom user-agent is not overwritten by Carbon analytics user-agent");
-
-			test.Complete();
-		}
-
-		[Integrations.Test.Assert(Timeout = 20_000)]
-		public async Task default_user_agent_is_carbon_analytics(Integrations.Test.Assert test)
-		{
-			var expectedUserAgent = Community.Runtime.Analytics.UserAgent;
-			var capture = await CaptureInboundUserAgent(test, headers: null);
-
-			test.IsTrue(capture.CallbackCount == 1, "default user-agent callback invoked once");
-			test.IsTrue(capture.CallbackCode == 204, "default user-agent callback status code is 204");
-			test.IsTrue(!string.IsNullOrEmpty(expectedUserAgent), "carbon analytics user-agent is available");
-			test.IsTrue(capture.ReceivedUserAgent == expectedUserAgent,
-				$"default user-agent is Carbon analytics (got '{capture.ReceivedUserAgent}')");
-
-			test.Complete();
-		}
-
-		private static async Task<UserAgentCaptureResult> CaptureInboundUserAgent(
-			Integrations.Test.Assert test, Dictionary<string, string> headers
-		)
-		{
-			var listener = new TcpListener(IPAddress.Loopback, 0);
-			listener.Start();
-			var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-			var url = $"http://127.0.0.1:{port}/user-agent-probe";
-
-			string receivedUserAgent = null;
-			var acceptTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-			var acceptTask = Task.Run(async () =>
-			{
-				try
-				{
-					using var client = await listener.AcceptTcpClientAsync();
-					using var stream = client.GetStream();
-					using var reader = new System.IO.StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
-
-					string line;
-					while ((line = await reader.ReadLineAsync()) != null)
-					{
-						if (line.Length == 0)
-						{
-							break;
-						}
-
-						const string userAgentPrefix = "User-Agent:";
-						if (line.StartsWith(userAgentPrefix, StringComparison.OrdinalIgnoreCase))
-						{
-							receivedUserAgent = line.Substring(userAgentPrefix.Length).Trim();
-						}
-					}
-
-					var responseBytes = Encoding.ASCII.GetBytes("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
-					await stream.WriteAsync(responseBytes, 0, responseBytes.Length);
-					acceptTcs.TrySetResult(true);
-				}
-				catch (Exception ex)
-				{
-					acceptTcs.TrySetException(ex);
-				}
-			});
-
-			try
-			{
-				var result = await ExecuteStringRequest(url, RequestMethod.GET, null, test, headers: headers);
-				var acceptFinished = await Task.WhenAny(acceptTcs.Task, Task.Delay(8_000));
-				test.IsTrue(acceptFinished == acceptTcs.Task, "local listener accepted inbound request");
-
-				if (acceptTcs.Task.IsFaulted)
-				{
-					await acceptTcs.Task;
-				}
-
-				await Task.WhenAny(acceptTask, Task.Delay(1_000));
-
-				return new UserAgentCaptureResult
-				{
-					CallbackCount = result.CallbackCount,
-					CallbackCode = result.CallbackCode,
-					ReceivedUserAgent = receivedUserAgent,
-				};
-			}
-			finally
-			{
-				listener.Stop();
-			}
-		}
-
 		private static async Task<StringGetResult> ExecuteStringGet(string url, Integrations.Test.Assert test)
 		{
 			return await ExecuteStringRequest(url, RequestMethod.GET, null, test);
@@ -541,7 +532,7 @@ public partial class Tests
 
 		private static async Task<StringGetResult> ExecuteStringRequest(
 			string url, RequestMethod method, string body, Integrations.Test.Assert test, int callbackTimeoutMs = 8_000,
-			Dictionary<string, string> headers = null
+			Dictionary<string, string> headers = null, float timeout = 15f
 		)
 		{
 			var callbackTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -558,7 +549,7 @@ public partial class Tests
 				callbackBody = callbackBodyValue;
 				callbackThreadId = Thread.CurrentThread.ManagedThreadId;
 				callbackTcs.TrySetResult(true);
-			}, singleton, method, headers, timeout: 15f);
+			}, singleton, method, headers, timeout);
 
 			var callbackFinished = await Task.WhenAny(callbackTcs.Task, Task.Delay(callbackTimeoutMs));
 			test.IsTrue(callbackFinished == callbackTcs.Task, $"callback invoked ({method} {url})");
@@ -582,11 +573,99 @@ public partial class Tests
 			public int CallbackThreadId;
 		}
 
-		private struct UserAgentCaptureResult
+		private sealed class LoopbackProbe : IDisposable
 		{
-			public int CallbackCount;
-			public int CallbackCode;
-			public string ReceivedUserAgent;
+			private const int CaptureTimeoutMs = 8_000;
+
+			private readonly TcpListener _listener;
+			private readonly TaskCompletionSource<string> _head =
+				new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			private TcpClient _accepted;
+			private bool _disposed;
+
+			public string Url { get; }
+
+			public LoopbackProbe(bool respond = true)
+			{
+				_listener = new TcpListener(IPAddress.Loopback, 0);
+				_listener.Start();
+
+				Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/probe";
+
+				_ = Task.Run(() => Capture(respond));
+			}
+
+			public async Task<string> GetHeader(string name)
+			{
+				var captured = await Task.WhenAny(_head.Task, Task.Delay(CaptureTimeoutMs));
+				var head = captured == _head.Task ? _head.Task.Result : null;
+
+				if (string.IsNullOrEmpty(head))
+				{
+					return null;
+				}
+
+				var prefix = $"{name}:";
+				var lines = head.Split('\n');
+
+				for (var i = 0; i < lines.Length; i++)
+				{
+					var line = lines[i].Trim();
+
+					if (line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+					{
+						return line.Substring(prefix.Length).Trim();
+					}
+				}
+
+				return string.Empty;
+			}
+
+			private async Task Capture(bool respond)
+			{
+				try
+				{
+					_accepted = await _listener.AcceptTcpClientAsync();
+
+					var stream = _accepted.GetStream();
+					var reader = new StreamReader(stream, Encoding.ASCII, false, 256, true);
+					var head = new StringBuilder();
+
+					string line;
+
+					while (!string.IsNullOrEmpty(line = await reader.ReadLineAsync()))
+					{
+						head.AppendLine(line);
+					}
+
+					_head.TrySetResult(head.ToString());
+
+					if (respond)
+					{
+						var response = Encoding.ASCII.GetBytes("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
+						await stream.WriteAsync(response, 0, response.Length);
+						_accepted.Close();
+					}
+				}
+				catch
+				{
+					_head.TrySetResult(null);
+				}
+			}
+
+			public void Dispose()
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+				_head.TrySetResult(null);
+				_accepted?.Close();
+				_listener.Stop();
+			}
 		}
 	}
 }

--- a/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
+++ b/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
@@ -1,5 +1,9 @@
 #if !TESTS_NO_WEBREQUEST
 using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Carbon.Extensions;
@@ -14,6 +18,7 @@ public partial class Tests
 	{
 		private const string HttpsGenerate204Url = "https://www.gstatic.com/generate_204";
 		private const string HttpGenerate204Url = "http://www.gstatic.com/generate_204";
+		private const string CustomPluginUserAgent = "Server Armour/2.87.0 <Carbon>";
 
 		[Integrations.Test.Assert]
 		public void validate_library(Integrations.Test.Assert test)
@@ -425,13 +430,118 @@ public partial class Tests
 			}
 		}
 
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task custom_user_agent_header_is_preserved(Integrations.Test.Assert test)
+		{
+			var capture = await CaptureInboundUserAgent(test, new Dictionary<string, string>
+			{
+				["User-Agent"] = CustomPluginUserAgent,
+			});
+
+			test.IsTrue(capture.CallbackCount == 1, "custom user-agent callback invoked once");
+			test.IsTrue(capture.CallbackCode == 204, "custom user-agent callback status code is 204");
+			test.IsTrue(capture.ReceivedUserAgent == CustomPluginUserAgent,
+				$"custom user-agent was sent (got '{capture.ReceivedUserAgent}')");
+			test.IsTrue(!string.Equals(capture.ReceivedUserAgent, Community.Runtime.Analytics.UserAgent, StringComparison.Ordinal),
+				"custom user-agent is not overwritten by Carbon analytics user-agent");
+
+			test.Complete();
+		}
+
+		[Integrations.Test.Assert(Timeout = 20_000)]
+		public async Task default_user_agent_is_carbon_analytics(Integrations.Test.Assert test)
+		{
+			var expectedUserAgent = Community.Runtime.Analytics.UserAgent;
+			var capture = await CaptureInboundUserAgent(test, headers: null);
+
+			test.IsTrue(capture.CallbackCount == 1, "default user-agent callback invoked once");
+			test.IsTrue(capture.CallbackCode == 204, "default user-agent callback status code is 204");
+			test.IsTrue(!string.IsNullOrEmpty(expectedUserAgent), "carbon analytics user-agent is available");
+			test.IsTrue(capture.ReceivedUserAgent == expectedUserAgent,
+				$"default user-agent is Carbon analytics (got '{capture.ReceivedUserAgent}')");
+
+			test.Complete();
+		}
+
+		private static async Task<UserAgentCaptureResult> CaptureInboundUserAgent(
+			Integrations.Test.Assert test, Dictionary<string, string> headers
+		)
+		{
+			var listener = new TcpListener(IPAddress.Loopback, 0);
+			listener.Start();
+			var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+			var url = $"http://127.0.0.1:{port}/user-agent-probe";
+
+			string receivedUserAgent = null;
+			var acceptTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			var acceptTask = Task.Run(async () =>
+			{
+				try
+				{
+					using var client = await listener.AcceptTcpClientAsync();
+					using var stream = client.GetStream();
+					using var reader = new System.IO.StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+
+					string line;
+					while ((line = await reader.ReadLineAsync()) != null)
+					{
+						if (line.Length == 0)
+						{
+							break;
+						}
+
+						const string userAgentPrefix = "User-Agent:";
+						if (line.StartsWith(userAgentPrefix, StringComparison.OrdinalIgnoreCase))
+						{
+							receivedUserAgent = line.Substring(userAgentPrefix.Length).Trim();
+						}
+					}
+
+					var responseBytes = Encoding.ASCII.GetBytes("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
+					await stream.WriteAsync(responseBytes, 0, responseBytes.Length);
+					acceptTcs.TrySetResult(true);
+				}
+				catch (Exception ex)
+				{
+					acceptTcs.TrySetException(ex);
+				}
+			});
+
+			try
+			{
+				var result = await ExecuteStringRequest(url, RequestMethod.GET, null, test, headers: headers);
+				var acceptFinished = await Task.WhenAny(acceptTcs.Task, Task.Delay(8_000));
+				test.IsTrue(acceptFinished == acceptTcs.Task, "local listener accepted inbound request");
+
+				if (acceptTcs.Task.IsFaulted)
+				{
+					await acceptTcs.Task;
+				}
+
+				await Task.WhenAny(acceptTask, Task.Delay(1_000));
+
+				return new UserAgentCaptureResult
+				{
+					CallbackCount = result.CallbackCount,
+					CallbackCode = result.CallbackCode,
+					ReceivedUserAgent = receivedUserAgent,
+				};
+			}
+			finally
+			{
+				listener.Stop();
+			}
+		}
+
 		private static async Task<StringGetResult> ExecuteStringGet(string url, Integrations.Test.Assert test)
 		{
 			return await ExecuteStringRequest(url, RequestMethod.GET, null, test);
 		}
 
 		private static async Task<StringGetResult> ExecuteStringRequest(
-			string url, RequestMethod method, string body, Integrations.Test.Assert test, int callbackTimeoutMs = 8_000
+			string url, RequestMethod method, string body, Integrations.Test.Assert test, int callbackTimeoutMs = 8_000,
+			Dictionary<string, string> headers = null
 		)
 		{
 			var callbackTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -448,7 +558,7 @@ public partial class Tests
 				callbackBody = callbackBodyValue;
 				callbackThreadId = Thread.CurrentThread.ManagedThreadId;
 				callbackTcs.TrySetResult(true);
-			}, singleton, method, timeout: 15f);
+			}, singleton, method, headers, timeout: 15f);
 
 			var callbackFinished = await Task.WhenAny(callbackTcs.Task, Task.Delay(callbackTimeoutMs));
 			test.IsTrue(callbackFinished == callbackTcs.Task, $"callback invoked ({method} {url})");
@@ -470,6 +580,13 @@ public partial class Tests
 			public int CallbackCode;
 			public string CallbackBody;
 			public int CallbackThreadId;
+		}
+
+		private struct UserAgentCaptureResult
+		{
+			public int CallbackCount;
+			public int CallbackCode;
+			public string ReceivedUserAgent;
 		}
 	}
 }

--- a/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
+++ b/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
@@ -206,10 +206,10 @@ public partial class Tests
 		[Integrations.Test.Assert(Timeout = 20_000)]
 		public async Task default_user_agent_is_carbons(Integrations.Test.Assert test)
 		{
-			using var probe = new LoopbackProbe();
+			using var server = new LoopbackServer();
 
-			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test);
-			var userAgent = await probe.GetHeader("User-Agent");
+			var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test);
+			var userAgent = await server.GetHeader("User-Agent");
 
 			test.IsTrue(result.CallbackCode == 204, $"default user agent request completed ({result.CallbackCode})");
 			test.IsTrue(userAgent == Community.Runtime.Analytics.UserAgent,
@@ -221,11 +221,11 @@ public partial class Tests
 		[Integrations.Test.Assert(Timeout = 20_000)]
 		public async Task custom_user_agent_is_preserved(Integrations.Test.Assert test)
 		{
-			using var probe = new LoopbackProbe();
+			using var server = new LoopbackServer();
 
-			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test,
+			var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test,
 				headers: new Dictionary<string, string> { ["User-Agent"] = CustomUserAgent });
-			var userAgent = await probe.GetHeader("User-Agent");
+			var userAgent = await server.GetHeader("User-Agent");
 
 			test.IsTrue(result.CallbackCode == 204, $"custom user agent request completed ({result.CallbackCode})");
 			test.IsTrue(userAgent == CustomUserAgent, $"custom user agent reached the wire (got '{userAgent}')");
@@ -236,11 +236,11 @@ public partial class Tests
 		[Integrations.Test.Assert(Timeout = 20_000)]
 		public async Task custom_user_agent_is_case_insensitive(Integrations.Test.Assert test)
 		{
-			using var probe = new LoopbackProbe();
+			using var server = new LoopbackServer();
 
-			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test,
+			var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test,
 				headers: new Dictionary<string, string> { ["user-agent"] = CustomUserAgent });
-			var userAgent = await probe.GetHeader("User-Agent");
+			var userAgent = await server.GetHeader("User-Agent");
 
 			test.IsTrue(result.CallbackCode == 204, $"lowercase user agent request completed ({result.CallbackCode})");
 			test.IsTrue(userAgent == CustomUserAgent, $"lowercase user agent reached the wire (got '{userAgent}')");
@@ -251,10 +251,10 @@ public partial class Tests
 		[Integrations.Test.Assert(Timeout = 20_000)]
 		public async Task timeout_aborts_a_stalled_request(Integrations.Test.Assert test)
 		{
-			using var probe = new LoopbackProbe(respond: false);
+			using var server = new LoopbackServer(respond: false);
 
 			var started = DateTime.UtcNow;
-			var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test, 12_000, timeout: 2f);
+			var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test, 12_000, timeout: 2f);
 			var elapsed = (DateTime.UtcNow - started).TotalMilliseconds;
 
 			test.IsTrue(result.CallbackCount == 1, "stalled request callback invoked once");
@@ -275,14 +275,14 @@ public partial class Tests
 				return;
 			}
 
-			using var probe = new LoopbackProbe();
+			using var server = new LoopbackServer();
 
 			var previousIp = Community.Runtime.Config.WebRequestIp;
 			Community.Runtime.Config.WebRequestIp = UnreachableBindIp;
 
 			try
 			{
-				var result = await ExecuteStringRequest(probe.Url, RequestMethod.GET, null, test);
+				var result = await ExecuteStringRequest(server.Url, RequestMethod.GET, null, test);
 
 				test.IsNull(result.Request.ResponseError, "loopback request has no response error");
 				test.IsTrue(result.CallbackCode == 204,
@@ -301,78 +301,9 @@ public partial class Tests
 		{
 			const int requestCount = 48;
 
-			var allCallbacksTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-			var mainThreadId = ThreadEx.MainThread.ManagedThreadId;
+			using var server = new LoopbackServer();
 
-			var completed = 0;
-			var callbackCounts = new int[requestCount];
-			var callbackCodes = new int[requestCount];
-			var callbackThreadIds = new int[requestCount];
-			var callbackBodies = new string[requestCount];
-
-			for (var i = 0; i < requestCount; i++)
-			{
-				callbackCodes[i] = -1;
-				callbackThreadIds[i] = -1;
-				var requestIndex = i;
-
-				singleton.webrequest.Enqueue(HttpsGenerate204Url, null, (code, body) =>
-				{
-					Interlocked.Increment(ref callbackCounts[requestIndex]);
-					callbackCodes[requestIndex] = code;
-					callbackThreadIds[requestIndex] = Thread.CurrentThread.ManagedThreadId;
-					callbackBodies[requestIndex] = body;
-
-					if (Interlocked.Increment(ref completed) == requestCount)
-					{
-						allCallbacksTcs.TrySetResult(true);
-					}
-				}, singleton, timeout: 15f);
-			}
-
-			var callbacksFinished = await Task.WhenAny(allCallbacksTcs.Task, Task.Delay(12_000));
-
-			test.IsTrue(callbacksFinished == allCallbacksTcs.Task,
-				$"burst callbacks completed ({completed}/{requestCount})");
-
-			var missingCallbacks = 0;
-			var duplicateCallbacks = 0;
-			var wrongStatusCodes = 0;
-			var wrongThreadCallbacks = 0;
-			var nonEmptyBodies = 0;
-
-			for (var i = 0; i < requestCount; i++)
-			{
-				if (callbackCounts[i] == 0)
-				{
-					missingCallbacks++;
-				}
-				else if (callbackCounts[i] > 1)
-				{
-					duplicateCallbacks += callbackCounts[i] - 1;
-				}
-
-				if (callbackCodes[i] != 204)
-				{
-					wrongStatusCodes++;
-				}
-
-				if (callbackThreadIds[i] != mainThreadId)
-				{
-					wrongThreadCallbacks++;
-				}
-
-				if (!string.IsNullOrEmpty(callbackBodies[i]))
-				{
-					nonEmptyBodies++;
-				}
-			}
-
-			test.IsTrue(missingCallbacks == 0, $"burst has no missing callbacks ({missingCallbacks})");
-			test.IsTrue(duplicateCallbacks == 0, $"burst has no duplicate callbacks ({duplicateCallbacks})");
-			test.IsTrue(wrongStatusCodes == 0, $"burst callback status codes are 204 ({wrongStatusCodes} wrong)");
-			test.IsTrue(wrongThreadCallbacks == 0, $"burst callbacks are on main thread ({wrongThreadCallbacks} wrong)");
-			test.IsTrue(nonEmptyBodies == 0, $"burst callback bodies are empty ({nonEmptyBodies} non-empty)");
+			AssertBurst(test, "burst", requestCount, await ExecuteBurst(server.Url, requestCount, 12_000));
 
 			test.Complete();
 		}
@@ -382,146 +313,59 @@ public partial class Tests
 		{
 			const int requestCount = 16;
 
-			ThreadPool.GetMaxThreads(out var maxWorkerThreads, out _);
-			ThreadPool.GetAvailableThreads(out var availableBeforeWorkers, out _);
+			using var server = new LoopbackServer();
 
-			var pressureWorkers = Math.Clamp(Environment.ProcessorCount * 2, 8, 32);
-			var pressureStartTarget = Math.Min(pressureWorkers, 4);
+			var workerCount = Math.Clamp(Environment.ProcessorCount * 2, 8, 32);
+			var startTarget = Math.Min(workerCount, 4);
+			var release = new ManualResetEventSlim(false);
+			var workers = new Task[workerCount];
+			var started = 0;
+			var faults = 0;
 
-			var pressureStarted = 0;
-			var pressureFaults = 0;
-			var pressureTasks = new Task[pressureWorkers];
-			var pressureRelease = new ManualResetEventSlim(false);
-
-			for (var i = 0; i < pressureWorkers; i++)
+			for (var i = 0; i < workerCount; i++)
 			{
-				pressureTasks[i] = Task.Run(() =>
+				workers[i] = Task.Run(() =>
 				{
 					try
 					{
-						Interlocked.Increment(ref pressureStarted);
-						pressureRelease.Wait(1_500);
+						Interlocked.Increment(ref started);
+						release.Wait(1_500);
 					}
 					catch
 					{
-						Interlocked.Increment(ref pressureFaults);
+						Interlocked.Increment(ref faults);
 					}
 				});
 			}
 
 			try
 			{
-				var pressureReadyTask = Task.Run(async () =>
+				var ready = Task.Run(async () =>
 				{
-					while (Volatile.Read(ref pressureStarted) < pressureStartTarget)
+					while (Volatile.Read(ref started) < startTarget)
 					{
 						await Task.Delay(10);
 					}
 				});
-				await Task.WhenAny(pressureReadyTask, Task.Delay(600));
 
-				ThreadPool.GetAvailableThreads(out var availableDuringWorkers, out _);
+				await Task.WhenAny(ready, Task.Delay(600));
 
-				if (pressureReadyTask.IsCompleted)
+				if (!ready.IsCompleted)
 				{
-					test.Log($"threadpool pressure workers reached startup target ({pressureStarted}/{pressureStartTarget})");
-				}
-				else
-				{
-					test.Warn($"threadpool pressure workers did not reach startup target in time ({pressureStarted}/{pressureStartTarget})");
+					test.Warn($"threadpool pressure did not reach its startup target ({started}/{startTarget})");
 				}
 
-				if (availableDuringWorkers < availableBeforeWorkers)
-				{
-					test.Log($"threadpool pressure reduced available workers ({availableBeforeWorkers} -> {availableDuringWorkers})");
-				}
-				else
-				{
-					test.Warn($"threadpool pressure did not reduce available workers ({availableBeforeWorkers} -> {availableDuringWorkers})");
-				}
+				AssertBurst(test, "pressure burst", requestCount, await ExecuteBurst(server.Url, requestCount, 6_000));
 
-				var allCallbacksTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-				var mainThreadId = ThreadEx.MainThread.ManagedThreadId;
-
-				var completed = 0;
-				var callbackCounts = new int[requestCount];
-				var callbackCodes = new int[requestCount];
-				var callbackThreadIds = new int[requestCount];
-				var callbackBodies = new string[requestCount];
-
-				for (var i = 0; i < requestCount; i++)
-				{
-					callbackCodes[i] = -1;
-					callbackThreadIds[i] = -1;
-					var requestIndex = i;
-
-					singleton.webrequest.Enqueue(HttpsGenerate204Url, null, (code, body) =>
-					{
-						Interlocked.Increment(ref callbackCounts[requestIndex]);
-						callbackCodes[requestIndex] = code;
-						callbackThreadIds[requestIndex] = Thread.CurrentThread.ManagedThreadId;
-						callbackBodies[requestIndex] = body;
-
-						if (Interlocked.Increment(ref completed) == requestCount)
-						{
-							allCallbacksTcs.TrySetResult(true);
-						}
-					}, singleton, timeout: 15f);
-				}
-
-				var callbacksFinished = await Task.WhenAny(allCallbacksTcs.Task, Task.Delay(6_000));
-
-				test.IsTrue(callbacksFinished == allCallbacksTcs.Task,
-					$"pressure burst callbacks completed ({completed}/{requestCount})");
-
-				var missingCallbacks = 0;
-				var duplicateCallbacks = 0;
-				var wrongStatusCodes = 0;
-				var wrongThreadCallbacks = 0;
-				var nonEmptyBodies = 0;
-
-				for (var i = 0; i < requestCount; i++)
-				{
-					if (callbackCounts[i] == 0)
-					{
-						missingCallbacks++;
-					}
-					else if (callbackCounts[i] > 1)
-					{
-						duplicateCallbacks += callbackCounts[i] - 1;
-					}
-
-					if (callbackCodes[i] != 204)
-					{
-						wrongStatusCodes++;
-					}
-
-					if (callbackThreadIds[i] != mainThreadId)
-					{
-						wrongThreadCallbacks++;
-					}
-
-					if (!string.IsNullOrEmpty(callbackBodies[i]))
-					{
-						nonEmptyBodies++;
-					}
-				}
-
-				test.IsTrue(missingCallbacks == 0, $"pressure burst has no missing callbacks ({missingCallbacks})");
-				test.IsTrue(duplicateCallbacks == 0, $"pressure burst has no duplicate callbacks ({duplicateCallbacks})");
-				test.IsTrue(wrongStatusCodes == 0, $"pressure burst callback status codes are 204 ({wrongStatusCodes} wrong)");
-				test.IsTrue(wrongThreadCallbacks == 0, $"pressure burst callbacks are on main thread ({wrongThreadCallbacks} wrong)");
-				test.IsTrue(nonEmptyBodies == 0, $"pressure burst callback bodies are empty ({nonEmptyBodies} non-empty)");
-
-				test.IsTrue(pressureFaults == 0, $"threadpool pressure workers faulted ({pressureFaults})");
+				test.IsTrue(faults == 0, $"threadpool pressure workers faulted ({faults})");
 
 				test.Complete();
 			}
 			finally
 			{
-				pressureRelease.Set();
-				await Task.WhenAny(Task.WhenAll(pressureTasks), Task.Delay(2_000));
-				pressureRelease.Dispose();
+				release.Set();
+				await Task.WhenAny(Task.WhenAll(workers), Task.Delay(2_000));
+				release.Dispose();
 			}
 		}
 
@@ -573,33 +417,128 @@ public partial class Tests
 			public int CallbackThreadId;
 		}
 
-		private sealed class LoopbackProbe : IDisposable
+		private static async Task<BurstResult> ExecuteBurst(string url, int requestCount, int callbackTimeoutMs)
+		{
+			var allCallbacksTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+			var mainThreadId = ThreadEx.MainThread.ManagedThreadId;
+
+			var callbackCounts = new int[requestCount];
+			var callbackCodes = new int[requestCount];
+			var callbackThreadIds = new int[requestCount];
+			var callbackBodies = new string[requestCount];
+			var completed = 0;
+
+			for (var i = 0; i < requestCount; i++)
+			{
+				var requestIndex = i;
+
+				callbackCodes[requestIndex] = -1;
+				callbackThreadIds[requestIndex] = -1;
+
+				singleton.webrequest.Enqueue(url, null, (code, body) =>
+				{
+					Interlocked.Increment(ref callbackCounts[requestIndex]);
+					callbackCodes[requestIndex] = code;
+					callbackThreadIds[requestIndex] = Thread.CurrentThread.ManagedThreadId;
+					callbackBodies[requestIndex] = body;
+
+					if (Interlocked.Increment(ref completed) == requestCount)
+					{
+						allCallbacksTcs.TrySetResult(true);
+					}
+				}, singleton, timeout: 15f);
+			}
+
+			var callbacksFinished = await Task.WhenAny(allCallbacksTcs.Task, Task.Delay(callbackTimeoutMs));
+			var result = new BurstResult
+			{
+				AllCompleted = callbacksFinished == allCallbacksTcs.Task,
+				Completed = completed,
+			};
+
+			for (var i = 0; i < requestCount; i++)
+			{
+				if (callbackCounts[i] == 0)
+				{
+					result.Missing++;
+				}
+				else if (callbackCounts[i] > 1)
+				{
+					result.Duplicates += callbackCounts[i] - 1;
+				}
+
+				if (callbackCodes[i] != 204)
+				{
+					result.WrongCodes++;
+				}
+
+				if (callbackThreadIds[i] != mainThreadId)
+				{
+					result.WrongThreads++;
+				}
+
+				if (!string.IsNullOrEmpty(callbackBodies[i]))
+				{
+					result.NonEmptyBodies++;
+				}
+			}
+
+			return result;
+		}
+
+		private static void AssertBurst(Integrations.Test.Assert test, string label, int requestCount, BurstResult result)
+		{
+			test.IsTrue(result.AllCompleted, $"{label} callbacks completed ({result.Completed}/{requestCount})");
+			test.IsTrue(result.Missing == 0, $"{label} has no missing callbacks ({result.Missing})");
+			test.IsTrue(result.Duplicates == 0, $"{label} has no duplicate callbacks ({result.Duplicates})");
+			test.IsTrue(result.WrongCodes == 0, $"{label} callback status codes are 204 ({result.WrongCodes} wrong)");
+			test.IsTrue(result.WrongThreads == 0, $"{label} callbacks are on main thread ({result.WrongThreads} wrong)");
+			test.IsTrue(result.NonEmptyBodies == 0, $"{label} callback bodies are empty ({result.NonEmptyBodies} non-empty)");
+		}
+
+		private struct BurstResult
+		{
+			public bool AllCompleted;
+			public int Completed;
+			public int Missing;
+			public int Duplicates;
+			public int WrongCodes;
+			public int WrongThreads;
+			public int NonEmptyBodies;
+		}
+
+		private sealed class LoopbackServer : IDisposable
 		{
 			private const int CaptureTimeoutMs = 8_000;
 
+			private static readonly byte[] NoContentResponse =
+				Encoding.ASCII.GetBytes("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
+
 			private readonly TcpListener _listener;
-			private readonly TaskCompletionSource<string> _head =
+			private readonly bool _respond;
+			private readonly List<TcpClient> _clients = new List<TcpClient>();
+			private readonly TaskCompletionSource<string> _firstHead =
 				new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			private TcpClient _accepted;
 			private bool _disposed;
 
 			public string Url { get; }
 
-			public LoopbackProbe(bool respond = true)
+			public LoopbackServer(bool respond = true)
 			{
+				_respond = respond;
 				_listener = new TcpListener(IPAddress.Loopback, 0);
 				_listener.Start();
 
 				Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/probe";
 
-				_ = Task.Run(() => Capture(respond));
+				_ = Task.Run(Accept);
 			}
 
 			public async Task<string> GetHeader(string name)
 			{
-				var captured = await Task.WhenAny(_head.Task, Task.Delay(CaptureTimeoutMs));
-				var head = captured == _head.Task ? _head.Task.Result : null;
+				var captured = await Task.WhenAny(_firstHead.Task, Task.Delay(CaptureTimeoutMs));
+				var head = captured == _firstHead.Task ? _firstHead.Task.Result : null;
 
 				if (string.IsNullOrEmpty(head))
 				{
@@ -622,13 +561,42 @@ public partial class Tests
 				return string.Empty;
 			}
 
-			private async Task Capture(bool respond)
+			private async Task Accept()
+			{
+				while (true)
+				{
+					TcpClient client;
+
+					try
+					{
+						client = await _listener.AcceptTcpClientAsync();
+					}
+					catch
+					{
+						_firstHead.TrySetResult(null);
+						return;
+					}
+
+					lock (_clients)
+					{
+						if (_disposed)
+						{
+							client.Close();
+							return;
+						}
+
+						_clients.Add(client);
+					}
+
+					_ = Task.Run(() => Serve(client));
+				}
+			}
+
+			private async Task Serve(TcpClient client)
 			{
 				try
 				{
-					_accepted = await _listener.AcceptTcpClientAsync();
-
-					var stream = _accepted.GetStream();
+					var stream = client.GetStream();
 					var reader = new StreamReader(stream, Encoding.ASCII, false, 256, true);
 					var head = new StringBuilder();
 
@@ -639,31 +607,40 @@ public partial class Tests
 						head.AppendLine(line);
 					}
 
-					_head.TrySetResult(head.ToString());
+					_firstHead.TrySetResult(head.ToString());
 
-					if (respond)
+					if (_respond)
 					{
-						var response = Encoding.ASCII.GetBytes("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
-						await stream.WriteAsync(response, 0, response.Length);
-						_accepted.Close();
+						await stream.WriteAsync(NoContentResponse, 0, NoContentResponse.Length);
+						client.Close();
 					}
 				}
 				catch
 				{
-					_head.TrySetResult(null);
+					_firstHead.TrySetResult(null);
 				}
 			}
 
 			public void Dispose()
 			{
-				if (_disposed)
+				lock (_clients)
 				{
-					return;
+					if (_disposed)
+					{
+						return;
+					}
+
+					_disposed = true;
+
+					for (var i = 0; i < _clients.Count; i++)
+					{
+						_clients[i].Close();
+					}
+
+					_clients.Clear();
 				}
 
-				_disposed = true;
-				_head.TrySetResult(null);
-				_accepted?.Close();
+				_firstHead.TrySetResult(null);
 				_listener.Stop();
 			}
 		}

--- a/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
+++ b/src/Carbon.Tests/Static/carbon/plugins/cszip_dev/Tests/Tests.WebRequest.cs
@@ -18,7 +18,7 @@ public partial class Tests
 	{
 		private const string HttpsGenerate204Url = "https://www.gstatic.com/generate_204";
 		private const string HttpGenerate204Url = "http://www.gstatic.com/generate_204";
-		private const string CustomPluginUserAgent = "Server Armour/2.87.0 <Carbon>";
+		private const string CustomPluginUserAgent = "Custom String";
 
 		[Integrations.Test.Assert]
 		public void validate_library(Integrations.Test.Assert test)


### PR DESCRIPTION
as the title and branchname suggests. allow plugins to set custom user-agents to identify themselves to api's being called. 